### PR TITLE
wip. replace target def with empty declaration

### DIFF
--- a/compiler/rustc_codegen_llvm/src/attributes.rs
+++ b/compiler/rustc_codegen_llvm/src/attributes.rs
@@ -53,7 +53,7 @@ fn inline_attr<'ll>(cx: &CodegenCx<'ll, '_>, inline: InlineAttr) -> Option<&'ll 
 pub fn sanitize_attrs<'ll>(
     cx: &CodegenCx<'ll, '_>,
     no_sanitize: SanitizerSet,
-) -> SmallVec<[&'ll Attribute; 4]> {
+    ) -> SmallVec<[&'ll Attribute; 4]> {
     let mut attrs = SmallVec::new();
     let enabled = cx.tcx.sess.opts.debugging_opts.sanitizer - no_sanitize;
     if enabled.contains(SanitizerSet::ADDRESS) {
@@ -119,10 +119,10 @@ fn instrument_function_attr<'ll>(cx: &CodegenCx<'ll, '_>) -> Option<&'ll Attribu
         let mcount_name = cx.sess().target.mcount.as_ref();
 
         Some(llvm::CreateAttrStringValue(
-            cx.llcx,
-            "instrument-function-entry-inlined",
-            &mcount_name,
-        ))
+                cx.llcx,
+                "instrument-function-entry-inlined",
+                &mcount_name,
+                ))
     } else {
         None
     }
@@ -134,13 +134,13 @@ fn probestack_attr<'ll>(cx: &CodegenCx<'ll, '_>) -> Option<&'ll Attribute> {
     // stack overflow anyway so we don't really need stack probes regardless.
     if cx
         .sess()
-        .opts
-        .debugging_opts
-        .sanitizer
-        .intersects(SanitizerSet::ADDRESS | SanitizerSet::THREAD)
-    {
-        return None;
-    }
+            .opts
+            .debugging_opts
+            .sanitizer
+            .intersects(SanitizerSet::ADDRESS | SanitizerSet::THREAD)
+            {
+                return None;
+            }
 
     // probestack doesn't play nice either with `-C profile-generate`.
     if cx.sess().opts.cg.profile_generate.enabled() {
@@ -208,7 +208,7 @@ pub fn non_lazy_bind_attr<'ll>(cx: &CodegenCx<'ll, '_>) -> Option<&'ll Attribute
 #[inline]
 pub(crate) fn default_optimisation_attrs<'ll>(
     cx: &CodegenCx<'ll, '_>,
-) -> SmallVec<[&'ll Attribute; 2]> {
+    ) -> SmallVec<[&'ll Attribute; 2]> {
     let mut attrs = SmallVec::new();
     match cx.sess().opts.optimize {
         OptLevel::Size => {
@@ -229,9 +229,9 @@ pub fn from_fn_attrs<'ll, 'tcx>(
     cx: &CodegenCx<'ll, 'tcx>,
     llfn: &'ll Value,
     instance: ty::Instance<'tcx>,
-) {
+    ) {
     let codegen_fn_attrs = cx.tcx.codegen_fn_attrs(instance.def_id());
-    let autodiff_attrs = cx.tcx.autodiff_attrs(instance.def_id());
+    let _autodiff_attrs = cx.tcx.autodiff_attrs(instance.def_id());
 
     let mut to_add = SmallVec::<[_; 16]>::new();
 
@@ -246,7 +246,7 @@ pub fn from_fn_attrs<'ll, 'tcx>(
         OptimizeAttr::Speed => {}
     }
 
-    let inline = if codegen_fn_attrs.flags.contains(CodegenFnAttrFlags::NAKED) || autodiff_attrs.is_active() {
+    let inline = if codegen_fn_attrs.flags.contains(CodegenFnAttrFlags::NAKED) {
         InlineAttr::Never
     } else if codegen_fn_attrs.inline == InlineAttr::None && instance.def.requires_inline(cx.tcx) {
         InlineAttr::Hint
@@ -327,7 +327,7 @@ pub fn from_fn_attrs<'ll, 'tcx>(
     if let Some(f) = llvm_util::check_tied_features(
         cx.tcx.sess,
         &function_features.iter().map(|f| (*f, true)).collect(),
-    ) {
+        ) {
         let span = cx
             .tcx
             .get_attrs(instance.def_id())
@@ -337,7 +337,7 @@ pub fn from_fn_attrs<'ll, 'tcx>(
         let msg = format!(
             "the target features {} must all be either enabled or disabled together",
             f.join(", ")
-        );
+            );
         let mut err = cx.tcx.sess.struct_span_err(span, &msg);
         err.help("add the missing features in a `target_feature` attribute");
         err.emit();
@@ -349,11 +349,11 @@ pub fn from_fn_attrs<'ll, 'tcx>(
         .flat_map(|feat| {
             llvm_util::to_llvm_features(cx.tcx.sess, feat).into_iter().map(|f| format!("+{}", f))
         })
-        .chain(codegen_fn_attrs.instruction_set.iter().map(|x| match x {
-            InstructionSetAttr::ArmA32 => "-thumb-mode".to_string(),
-            InstructionSetAttr::ArmT32 => "+thumb-mode".to_string(),
-        }))
-        .collect::<Vec<String>>();
+    .chain(codegen_fn_attrs.instruction_set.iter().map(|x| match x {
+        InstructionSetAttr::ArmA32 => "-thumb-mode".to_string(),
+        InstructionSetAttr::ArmT32 => "+thumb-mode".to_string(),
+    }))
+    .collect::<Vec<String>>();
 
     if cx.tcx.sess.target.is_like_wasm {
         // If this function is an import from the environment but the wasm

--- a/compiler/rustc_codegen_llvm/src/back/lto.rs
+++ b/compiler/rustc_codegen_llvm/src/back/lto.rs
@@ -225,7 +225,7 @@ fn fat_lto(
                 _ => None
             }
         })
-        .flatten()
+    .flatten()
         .collect();
 
     // Sort out all our lists of incoming modules into two lists.
@@ -756,7 +756,7 @@ pub unsafe fn optimize_thin_module(
     let llcx = llvm::LLVMRustContextCreate(cgcx.fewer_names);
     let llmod_raw = parse_module(llcx, module_name, thin_module.data(), &diag_handler)? as *const _;
     let module = ModuleCodegen {
-        module_llvm: ModuleLlvm { llmod_raw, llcx, tm, typetrees: Default::default() },
+        module_llvm: ModuleLlvm { llmod_raw, llcx, tm, typetrees: Default::default(), target_fncs: vec![] },
         name: thin_module.name().to_string(),
         kind: ModuleKind::Regular,
     };

--- a/compiler/rustc_codegen_llvm/src/lib.rs
+++ b/compiler/rustc_codegen_llvm/src/lib.rs
@@ -529,6 +529,7 @@ pub struct ModuleLlvm {
     llmod_raw: *const llvm::Module,
     tm: &'static mut llvm::TargetMachine,
     typetrees: FxHashMap<String, DiffTypeTree>,
+    target_fncs: Vec<String>,
 }
 
 unsafe impl Send for ModuleLlvm {}
@@ -539,7 +540,7 @@ impl ModuleLlvm {
         unsafe {
             let llcx = llvm::LLVMRustContextCreate(tcx.sess.fewer_names());
             let llmod_raw = context::create_module(tcx, llcx, mod_name) as *const _;
-            ModuleLlvm { llmod_raw, llcx, tm: create_target_machine(tcx, mod_name), typetrees: Default::default(), }
+            ModuleLlvm { llmod_raw, llcx, tm: create_target_machine(tcx, mod_name), typetrees: Default::default(), target_fncs: vec![] }
         }
     }
 
@@ -547,7 +548,7 @@ impl ModuleLlvm {
         unsafe {
             let llcx = llvm::LLVMRustContextCreate(tcx.sess.fewer_names());
             let llmod_raw = context::create_module(tcx, llcx, mod_name) as *const _;
-            ModuleLlvm { llmod_raw, llcx, tm: create_informational_target_machine(tcx.sess) , typetrees: Default::default() }
+            ModuleLlvm { llmod_raw, llcx, tm: create_informational_target_machine(tcx.sess) , typetrees: Default::default(), target_fncs: vec![] }
         }
     }
 
@@ -570,7 +571,7 @@ impl ModuleLlvm {
             };
 
 
-            Ok(ModuleLlvm { llmod_raw, llcx, tm, typetrees: Default::default() })
+            Ok(ModuleLlvm { llmod_raw, llcx, tm, typetrees: Default::default(), target_fncs: vec![] })
         }
     }
 

--- a/compiler/rustc_mir_transform/src/inline.rs
+++ b/compiler/rustc_mir_transform/src/inline.rs
@@ -81,7 +81,7 @@ fn inline<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) -> bool {
         def_id.to_def_id(),
         param_env,
         ObligationCause::misc(body.span, hir_id),
-    );
+        );
 
     let mut this = Inliner {
         tcx,
@@ -144,7 +144,13 @@ impl<'tcx> Inliner<'tcx> {
         &self,
         caller_body: &mut Body<'tcx>,
         callsite: &CallSite<'tcx>,
-    ) -> Result<std::ops::Range<BasicBlock>, &'static str> {
+        ) -> Result<std::ops::Range<BasicBlock>, &'static str> {
+        let caller_def_id = caller_body.source.def_id();
+        let autodiff_active = self.tcx.autodiff_attrs(caller_def_id).is_active();
+        dbg!("BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB");
+        if autodiff_active {
+            dbg!("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAASSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS");
+        }
         let callee_attrs = self.tcx.codegen_fn_attrs(callsite.callee.def_id());
         self.check_codegen_attributes(callsite, callee_attrs)?;
         self.check_mir_is_available(caller_body, &callsite.callee)?;
@@ -161,7 +167,7 @@ impl<'tcx> Inliner<'tcx> {
             self.tcx,
             self.param_env,
             callee_body.clone(),
-        );
+            );
 
         let old_blocks = caller_body.basic_blocks().next_index();
         self.inline_call(caller_body, &callsite, callee_body);
@@ -174,9 +180,15 @@ impl<'tcx> Inliner<'tcx> {
         &self,
         caller_body: &Body<'tcx>,
         callee: &Instance<'tcx>,
-    ) -> Result<(), &'static str> {
+        ) -> Result<(), &'static str> {
         let caller_def_id = caller_body.source.def_id();
         let callee_def_id = callee.def_id();
+        let autodiff_active = self.tcx.autodiff_attrs(caller_def_id).is_active();
+        if autodiff_active {
+            dbg!("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAASSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS");
+        }
+
+        // mark
         if callee_def_id == caller_def_id {
             return Err("self-recursion");
         }
@@ -199,11 +211,11 @@ impl<'tcx> Inliner<'tcx> {
             // do not need to catch this here, we can wait until the inliner decides to continue
             // inlining a second time.
             InstanceDef::VtableShim(_)
-            | InstanceDef::ReifyShim(_)
-            | InstanceDef::FnPtrShim(..)
-            | InstanceDef::ClosureOnceShim { .. }
+                | InstanceDef::ReifyShim(_)
+                | InstanceDef::FnPtrShim(..)
+                | InstanceDef::ClosureOnceShim { .. }
             | InstanceDef::DropGlue(..)
-            | InstanceDef::CloneShim(..) => return Ok(()),
+                | InstanceDef::CloneShim(..) => return Ok(()),
         }
 
         if self.tcx.is_constructor(callee_def_id) {
@@ -219,9 +231,9 @@ impl<'tcx> Inliner<'tcx> {
             // since `DefPathHash` is stable.
             if self.tcx.def_path_hash(caller_def_id).local_hash()
                 < self.tcx.def_path_hash(callee_def_id).local_hash()
-            {
-                return Ok(());
-            }
+                {
+                    return Ok(());
+                }
 
             // If we know for sure that the function we're calling will itself try to
             // call us, then we avoid inlining that function.
@@ -245,7 +257,7 @@ impl<'tcx> Inliner<'tcx> {
         caller_body: &Body<'tcx>,
         bb: BasicBlock,
         bb_data: &BasicBlockData<'tcx>,
-    ) -> Option<CallSite<'tcx>> {
+        ) -> Option<CallSite<'tcx>> {
         // Only consider direct calls to functions
         let terminator = bb_data.terminator();
         if let TerminatorKind::Call { ref func, ref destination, .. } = terminator.kind {
@@ -281,8 +293,9 @@ impl<'tcx> Inliner<'tcx> {
         &self,
         callsite: &CallSite<'tcx>,
         callee_attrs: &CodegenFnAttrs,
-    ) -> Result<(), &'static str> {
+        ) -> Result<(), &'static str> {
         if let InlineAttr::Never = callee_attrs.inline {
+            dbg!("never inline");
             return Err("never inline hint");
         }
 
@@ -333,7 +346,7 @@ impl<'tcx> Inliner<'tcx> {
         callsite: &CallSite<'tcx>,
         callee_body: &Body<'tcx>,
         callee_attrs: &CodegenFnAttrs,
-    ) -> Result<(), &'static str> {
+        ) -> Result<(), &'static str> {
         let tcx = self.tcx;
 
         let mut threshold = if callee_attrs.requests_inline() {
@@ -368,9 +381,9 @@ impl<'tcx> Inliner<'tcx> {
                 // Don't count StorageLive/StorageDead in the inlining cost.
                 match stmt.kind {
                     StatementKind::StorageLive(_)
-                    | StatementKind::StorageDead(_)
-                    | StatementKind::Deinit(_)
-                    | StatementKind::Nop => {}
+                        | StatementKind::StorageDead(_)
+                        | StatementKind::Deinit(_)
+                        | StatementKind::Nop => {}
                     _ => cost += INSTR_COST,
                 }
             }
@@ -396,7 +409,7 @@ impl<'tcx> Inliner<'tcx> {
                 }
 
                 TerminatorKind::Unreachable | TerminatorKind::Call { destination: None, .. }
-                    if first_block =>
+                if first_block =>
                 {
                     // If the function always diverges, don't inline
                     // unless the cost is zero
@@ -406,27 +419,27 @@ impl<'tcx> Inliner<'tcx> {
                 TerminatorKind::Call { func: Operand::Constant(ref f), cleanup, .. } => {
                     if let ty::FnDef(def_id, substs) =
                         *callsite.callee.subst_mir(self.tcx, &f.literal.ty()).kind()
-                    {
-                        let substs = self.tcx.normalize_erasing_regions(self.param_env, substs);
-                        if let Ok(Some(instance)) =
-                            Instance::resolve(self.tcx, self.param_env, def_id, substs)
                         {
-                            if callsite.callee.def_id() == instance.def_id() {
-                                return Err("self-recursion");
-                            } else if self.history.contains(&instance) {
-                                return Err("already inlined");
+                            let substs = self.tcx.normalize_erasing_regions(self.param_env, substs);
+                            if let Ok(Some(instance)) =
+                                Instance::resolve(self.tcx, self.param_env, def_id, substs)
+                                {
+                                    if callsite.callee.def_id() == instance.def_id() {
+                                        return Err("self-recursion");
+                                    } else if self.history.contains(&instance) {
+                                        return Err("already inlined");
+                                    }
+                                }
+                            // Don't give intrinsics the extra penalty for calls
+                            let f = tcx.fn_sig(def_id);
+                            if f.abi() == Abi::RustIntrinsic || f.abi() == Abi::PlatformIntrinsic {
+                                cost += INSTR_COST;
+                            } else {
+                                cost += CALL_PENALTY;
                             }
-                        }
-                        // Don't give intrinsics the extra penalty for calls
-                        let f = tcx.fn_sig(def_id);
-                        if f.abi() == Abi::RustIntrinsic || f.abi() == Abi::PlatformIntrinsic {
-                            cost += INSTR_COST;
                         } else {
                             cost += CALL_PENALTY;
                         }
-                    } else {
-                        cost += CALL_PENALTY;
-                    }
                     if cleanup.is_some() {
                         cost += LANDINGPAD_PENALTY;
                     }
@@ -493,7 +506,7 @@ impl<'tcx> Inliner<'tcx> {
         caller_body: &mut Body<'tcx>,
         callsite: &CallSite<'tcx>,
         mut callee_body: Body<'tcx>,
-    ) {
+        ) {
         let terminator = caller_body[callsite.block].terminator.take().unwrap();
         match terminator.kind {
             TerminatorKind::Call { args, destination, cleanup, .. } => {
@@ -520,7 +533,7 @@ impl<'tcx> Inliner<'tcx> {
                             self.tcx.lifetimes.re_erased,
                             BorrowKind::Mut { allow_two_phase_borrow: false },
                             destination_place,
-                        );
+                            );
                         let dest_ty = dest.ty(caller_body, self.tcx);
                         let temp = Place::from(self.new_call_temp(caller_body, &callsite, dest_ty));
                         caller_body[callsite.block].statements.push(Statement {
@@ -545,7 +558,7 @@ impl<'tcx> Inliner<'tcx> {
                     self.tcx.sess.edition(),
                     None,
                     None,
-                );
+                    );
                 expn_data.def_site = callee_body.span;
                 let expn_data =
                     LocalExpnId::fresh(expn_data, self.tcx.create_stable_hashing_context());
@@ -642,7 +655,7 @@ impl<'tcx> Inliner<'tcx> {
                             None => true,
                         }
                     }),
-                );
+                    );
             }
             kind => bug!("unexpected terminator kind {:?}", kind),
         }
@@ -654,7 +667,7 @@ impl<'tcx> Inliner<'tcx> {
         callsite: &CallSite<'tcx>,
         caller_body: &mut Body<'tcx>,
         callee_body: &Body<'tcx>,
-    ) -> Vec<Local> {
+        ) -> Vec<Local> {
         let tcx = self.tcx;
 
         // There is a bit of a mismatch between the *caller* of a closure and the *callee*.
@@ -718,14 +731,14 @@ impl<'tcx> Inliner<'tcx> {
         arg: Operand<'tcx>,
         callsite: &CallSite<'tcx>,
         caller_body: &mut Body<'tcx>,
-    ) -> Local {
+        ) -> Local {
         // Reuse the operand if it is a moved temporary.
         if let Operand::Move(place) = &arg
             && let Some(local) = place.as_local()
-            && caller_body.local_kind(local) == LocalKind::Temp
-        {
-            return local;
-        }
+                && caller_body.local_kind(local) == LocalKind::Temp
+                {
+                    return local;
+                }
 
         // Otherwise, create a temporary for the argument.
         trace!("creating temp for argument {:?}", arg);
@@ -744,7 +757,7 @@ impl<'tcx> Inliner<'tcx> {
         caller_body: &mut Body<'tcx>,
         callsite: &CallSite<'tcx>,
         ty: Ty<'tcx>,
-    ) -> Local {
+        ) -> Local {
         let local = caller_body.local_decls.push(LocalDecl::new(ty, callsite.source_info.span));
 
         caller_body[callsite.block].statements.push(Statement {
@@ -759,7 +772,7 @@ impl<'tcx> Inliner<'tcx> {
                     source_info: callsite.source_info,
                     kind: StatementKind::StorageDead(local),
                 },
-            );
+                );
         }
 
         local
@@ -770,7 +783,7 @@ fn type_size_of<'tcx>(
     tcx: TyCtxt<'tcx>,
     param_env: ty::ParamEnv<'tcx>,
     ty: Ty<'tcx>,
-) -> Option<u64> {
+    ) -> Option<u64> {
     tcx.layout_of(param_env.and(ty)).ok().map(|layout| layout.size.bytes())
 }
 
@@ -780,7 +793,7 @@ fn type_size_of<'tcx>(
  * Integrates blocks from the callee function into the calling function.
  * Updates block indices, references to locals and other control flow
  * stuff.
-*/
+ */
 struct Integrator<'a, 'tcx> {
     args: &'a [Local],
     new_locals: RangeFrom<Local>,
@@ -882,9 +895,9 @@ impl<'tcx> MutVisitor<'tcx> for Integrator<'_, 'tcx> {
     fn visit_statement(&mut self, statement: &mut Statement<'tcx>, location: Location) {
         if let StatementKind::StorageLive(local) | StatementKind::StorageDead(local) =
             statement.kind
-        {
-            self.always_live_locals.remove(local);
-        }
+            {
+                self.always_live_locals.remove(local);
+            }
         self.super_statement(statement, location);
     }
 
@@ -957,7 +970,7 @@ impl<'tcx> MutVisitor<'tcx> for Integrator<'_, 'tcx> {
                 *imaginary_target = self.map_block(*imaginary_target);
             }
             TerminatorKind::FalseUnwind { real_target: _, unwind: _ } =>
-            // see the ordering of passes in the optimized_mir query.
+                // see the ordering of passes in the optimized_mir query.
             {
                 bug!("False unwinds should have been removed before inlining")
             }

--- a/compiler/rustc_monomorphize/src/partitioning/default.rs
+++ b/compiler/rustc_monomorphize/src/partitioning/default.rs
@@ -26,7 +26,7 @@ impl<'tcx> Partitioner<'tcx> for DefaultPartitioning {
         &mut self,
         cx: &PartitioningCx<'_, 'tcx>,
         mono_items: &mut dyn Iterator<Item = MonoItem<'tcx>>,
-    ) -> PreInliningPartitioning<'tcx> {
+        ) -> PreInliningPartitioning<'tcx> {
         let mut roots = FxHashSet::default();
         let mut codegen_units = FxHashMap::default();
         let is_incremental_build = cx.tcx.sess.opts.incremental.is_some();
@@ -58,7 +58,7 @@ impl<'tcx> Partitioner<'tcx> for DefaultPartitioning {
                     def_id,
                     is_volatile,
                     cgu_name_cache,
-                ),
+                    ),
                 None => fallback_cgu_name(cgu_name_builder),
             };
 
@@ -66,16 +66,22 @@ impl<'tcx> Partitioner<'tcx> for DefaultPartitioning {
                 .entry(codegen_unit_name)
                 .or_insert_with(|| CodegenUnit::new(codegen_unit_name));
 
-            let mut can_be_internalized = true; 
+            let mut can_be_internalized = true;
 
             let (linkage, visibility) = mono_item_linkage_and_visibility(
                 cx.tcx,
                 &mono_item,
                 &mut can_be_internalized,
                 export_generics,
-            );
+                );
 
             let autodiff_active = characteristic_def_id.map(|x| cx.tcx.autodiff_attrs(x).is_active()).unwrap_or(false);
+            if autodiff_active {
+                dbg!("NOT INLINIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIING");
+                let name = mono_item.symbol_name(cx.tcx);
+                can_be_internalized = false;
+                dbg!(name);
+            }
 
             if !autodiff_active && visibility == Visibility::Hidden && can_be_internalized {
                 internalization_candidates.insert(mono_item);
@@ -97,8 +103,8 @@ impl<'tcx> Partitioner<'tcx> for DefaultPartitioning {
                 .into_iter()
                 .map(|(_, codegen_unit)| codegen_unit)
                 .collect(),
-            roots,
-            internalization_candidates,
+                roots,
+                internalization_candidates,
         }
     }
 
@@ -106,7 +112,7 @@ impl<'tcx> Partitioner<'tcx> for DefaultPartitioning {
         &mut self,
         cx: &PartitioningCx<'_, 'tcx>,
         initial_partitioning: &mut PreInliningPartitioning<'tcx>,
-    ) {
+        ) {
         merging::merge_codegen_units(cx, initial_partitioning);
     }
 
@@ -114,7 +120,7 @@ impl<'tcx> Partitioner<'tcx> for DefaultPartitioning {
         &mut self,
         cx: &PartitioningCx<'_, 'tcx>,
         initial_partitioning: PreInliningPartitioning<'tcx>,
-    ) -> PostInliningPartitioning<'tcx> {
+        ) -> PostInliningPartitioning<'tcx> {
         let mut new_partitioning = Vec::new();
         let mut mono_item_placements = FxHashMap::default();
 
@@ -145,8 +151,8 @@ impl<'tcx> Partitioner<'tcx> for DefaultPartitioning {
                         bug!(
                             "GloballyShared mono-item inlined into other CGU: \
                               {:?}",
-                            mono_item
-                        );
+                              mono_item
+                            );
                     }
 
                     // This is a CGU-private copy.
@@ -191,7 +197,7 @@ impl<'tcx> Partitioner<'tcx> for DefaultPartitioning {
             mono_item: MonoItem<'tcx>,
             inlining_map: &InliningMap<'tcx>,
             visited: &mut FxHashSet<MonoItem<'tcx>>,
-        ) {
+            ) {
             if !visited.insert(mono_item) {
                 return;
             }
@@ -206,11 +212,24 @@ impl<'tcx> Partitioner<'tcx> for DefaultPartitioning {
         &mut self,
         cx: &PartitioningCx<'_, 'tcx>,
         partitioning: &mut PostInliningPartitioning<'tcx>,
-    ) {
+        ) {
+        for _cgu in &mut partitioning.codegen_units {
+            for candidate in &partitioning.internalization_candidates {
+                let characteristic_def_id = characteristic_def_id_of_mono_item(cx.tcx, *candidate);
+                let autodiff_active = characteristic_def_id.map(|x| cx.tcx.autodiff_attrs(x).is_active()).unwrap_or(false);
+                if autodiff_active {
+                    dbg!("FAILED NOT INLINING AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+                    let name = (*candidate).symbol_name(cx.tcx);
+                    dbg!(name);
+                    panic!();
+                }
+            }
+        }
         if partitioning.codegen_units.len() == 1 {
             // Fast path for when there is only one codegen unit. In this case we
             // can internalize all candidates, since there is nowhere else they
             // could be accessed from.
+
             for cgu in &mut partitioning.codegen_units {
                 for candidate in &partitioning.internalization_candidates {
                     cgu.items_mut().insert(*candidate, (Linkage::Internal, Visibility::Default));
@@ -246,12 +265,12 @@ impl<'tcx> Partitioner<'tcx> for DefaultPartitioning {
                 if let Some(accessors) = accessor_map.get(accessee) {
                     if accessors
                         .iter()
-                        .filter_map(|accessor| {
-                            // Some accessors might not have been
-                            // instantiated. We can safely ignore those.
-                            mono_item_placements.get(accessor)
-                        })
-                        .any(|placement| *placement != home_cgu)
+                            .filter_map(|accessor| {
+                                // Some accessors might not have been
+                                // instantiated. We can safely ignore those.
+                                mono_item_placements.get(accessor)
+                            })
+                    .any(|placement| *placement != home_cgu)
                     {
                         // Found an accessor from another CGU, so skip to the next
                         // item without marking this one as internal.
@@ -270,19 +289,19 @@ impl<'tcx> Partitioner<'tcx> for DefaultPartitioning {
 fn characteristic_def_id_of_mono_item<'tcx>(
     tcx: TyCtxt<'tcx>,
     mono_item: MonoItem<'tcx>,
-) -> Option<DefId> {
+    ) -> Option<DefId> {
     match mono_item {
         MonoItem::Fn(instance) => {
             let def_id = match instance.def {
                 ty::InstanceDef::Item(def) => def.did,
                 ty::InstanceDef::VtableShim(..)
-                | ty::InstanceDef::ReifyShim(..)
-                | ty::InstanceDef::FnPtrShim(..)
-                | ty::InstanceDef::ClosureOnceShim { .. }
+                    | ty::InstanceDef::ReifyShim(..)
+                    | ty::InstanceDef::FnPtrShim(..)
+                    | ty::InstanceDef::ClosureOnceShim { .. }
                 | ty::InstanceDef::Intrinsic(..)
-                | ty::InstanceDef::DropGlue(..)
-                | ty::InstanceDef::Virtual(..)
-                | ty::InstanceDef::CloneShim(..) => return None,
+                    | ty::InstanceDef::DropGlue(..)
+                    | ty::InstanceDef::Virtual(..)
+                    | ty::InstanceDef::CloneShim(..) => return None,
             };
 
             // If this is a method, we want to put it into the same module as
@@ -298,12 +317,12 @@ fn characteristic_def_id_of_mono_item<'tcx>(
             if let Some(impl_def_id) = tcx.impl_of_method(def_id) {
                 if tcx.sess.opts.incremental.is_some()
                     && tcx.trait_id_of_impl(impl_def_id) == tcx.lang_items().drop_trait()
-                {
-                    // Put `Drop::drop` into the same cgu as `drop_in_place`
-                    // since `drop_in_place` is the only thing that can
-                    // call it.
-                    return None;
-                }
+                    {
+                        // Put `Drop::drop` into the same cgu as `drop_in_place`
+                        // since `drop_in_place` is the only thing that can
+                        // call it.
+                        return None;
+                    }
 
                 // When polymorphization is enabled, methods which do not depend on their generic
                 // parameters, but the self-type of their impl block do will fail to normalize.
@@ -313,7 +332,7 @@ fn characteristic_def_id_of_mono_item<'tcx>(
                         instance.substs,
                         ty::ParamEnv::reveal_all(),
                         tcx.type_of(impl_def_id),
-                    );
+                        );
                     if let Some(def_id) = characteristic_def_id_of_type(impl_self_ty) {
                         return Some(def_id);
                     }
@@ -333,7 +352,7 @@ fn compute_codegen_unit_name(
     def_id: DefId,
     volatile: bool,
     cache: &mut CguNameCache,
-) -> Symbol {
+    ) -> Symbol {
     // Find the innermost module that is not nested within a function.
     let mut current_def_id = def_id;
     let mut cgu_def_id = None;
@@ -385,11 +404,22 @@ fn mono_item_linkage_and_visibility<'tcx>(
     mono_item: &MonoItem<'tcx>,
     can_be_internalized: &mut bool,
     export_generics: bool,
-) -> (Linkage, Visibility) {
+    ) -> (Linkage, Visibility) {
+    let characteristic_def_id = characteristic_def_id_of_mono_item(tcx, *mono_item);
+    let autodiff_active = characteristic_def_id.map(|x| tcx.autodiff_attrs(x).is_active()).unwrap_or(false);
     if let Some(explicit_linkage) = mono_item.explicit_linkage(tcx) {
+        if autodiff_active {
+            dbg!("autodiff explicit_linkage visibility", Visibility::Default);
+            //External,
+        }
         return (explicit_linkage, Visibility::Default);
     }
     let vis = mono_item_visibility(tcx, mono_item, can_be_internalized, export_generics);
+    if autodiff_active {
+        *can_be_internalized = false;
+        dbg!(*can_be_internalized);
+        dbg!("autodiff item visibility", vis);
+    }
     (Linkage::External, vis)
 }
 
@@ -400,7 +430,7 @@ fn mono_item_visibility<'tcx>(
     mono_item: &MonoItem<'tcx>,
     can_be_internalized: &mut bool,
     export_generics: bool,
-) -> Visibility {
+    ) -> Visibility {
     let instance = match mono_item {
         // This is pretty complicated; see below.
         MonoItem::Fn(instance) => instance,
@@ -430,13 +460,13 @@ fn mono_item_visibility<'tcx>(
 
         // These are all compiler glue and such, never exported, always hidden.
         InstanceDef::VtableShim(..)
-        | InstanceDef::ReifyShim(..)
-        | InstanceDef::FnPtrShim(..)
-        | InstanceDef::Virtual(..)
-        | InstanceDef::Intrinsic(..)
-        | InstanceDef::ClosureOnceShim { .. }
+            | InstanceDef::ReifyShim(..)
+            | InstanceDef::FnPtrShim(..)
+            | InstanceDef::Virtual(..)
+            | InstanceDef::Intrinsic(..)
+            | InstanceDef::ClosureOnceShim { .. }
         | InstanceDef::DropGlue(..)
-        | InstanceDef::CloneShim(..) => return Visibility::Hidden,
+            | InstanceDef::CloneShim(..) => return Visibility::Hidden,
     };
 
     // The `start_fn` lang item is actually a monomorphized instance of a
@@ -458,6 +488,15 @@ fn mono_item_visibility<'tcx>(
     }
 
     let is_generic = instance.substs.non_erasable_generics().next().is_some();
+
+    let characteristic_def_id = characteristic_def_id_of_mono_item(tcx, *mono_item);
+    let autodiff_active = characteristic_def_id.map(|x| tcx.autodiff_attrs(x).is_active()).unwrap_or(false);
+    if autodiff_active {
+        // dbg!(*can_be_internalized); = true
+        *can_be_internalized = false;
+        dbg!(*can_be_internalized);
+        return Visibility::Default;
+    }
 
     // Upstream `DefId` instances get different handling than local ones.
     let Some(def_id) = def_id.as_local() else {


### PR DESCRIPTION
Once this works we can remove a couple of other hacks.
Just have to figure out how to tell llvm to not inline the pure declaration. should be more common than what we do right now.