### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# The Rust Programming Language
+# The Rust Programming Language +Enzyme
 
 This is the main source code repository for [Rust]. It contains the compiler,
 standard library, and documentation. It is modified to use Enzyme for AutoDiff.
@@ -6,17 +6,20 @@ standard library, and documentation. It is modified to use Enzyme for AutoDiff.
 Please configure this fork using the following command:
 
 ```
-./configure --enable-llvm-link-shared --enable-llvm-plugins --enable-llvm-enzyme --release-channel=nightly --enable-llvm-assertions --enable-clang --enable-lld --enable-option-checking --enable-ninja --disable-docs
+mkdir build
+cd build
+../configure --enable-llvm-link-shared --enable-llvm-plugins --enable-llvm-enzyme --release-channel=nightly --enable-llvm-assertions --enable-clang --enable-lld --enable-option-checking --enable-ninja --disable-docs
 ```
 
 Afterwards you can build rustc using:
 ```
-x build --stage 1 library/std   
+../x.py build --stage 1 library/std
 ```
 
-Afterwards rustc toolchain link will allow you to use it trough cargo (adjust path):
+Afterwards rustc toolchain link will allow you to use it through cargo:
 ```
-rustup toolchain link enzyme /home/drehwald/prog/rust/build/x86_64-unknown-linux-gnu/stage1
+rustup toolchain link enzyme `pwd`/build/`rustup target list --installed`/stage1
+rustup toolchain install nightly # enables -Z unstable-options
 ```
 
 [Rust]: https://www.rust-lang.org


### PR DESCRIPTION
Some updates, though I am still not sure it is complete, as I get that it can't find autodiff:
```
$ cargo +enzyme run --release --example sin -Z unstable-options --config 'lto="fat"' --verbose
   Compiling adRust v0.1.0 (/data/vtjnash/rust-ml-autodiff-examples)
     Running `rustc --crate-name sin --edition=2021 examples/sin.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --diagnostic-width=196 --crate-type bin --emit=dep-info,link -C opt-level=3 -C lto=fat -C metadata=64de30f76d150efa -C extra-filename=-64de30f76d150efa --out-dir /data/vtjnash/rust-ml-autodiff-examples/target/release/examples -L dependency=/data/vtjnash/rust-ml-autodiff-examples/target/release/deps`
error: cannot find attribute `autodiff` in this scope
 --> examples/sin.rs:1:3
  |
1 | #[autodiff()]
  |   ^^^^^^^^

error: cannot find attribute `autodiff` in this scope
 --> examples/sin.rs:5:3
  |
5 | #[autodiff(mode = "reverse", Active, Active)]
  |   ^^^^^^^^

error: could not compile `adRust` due to 2 previous errors

Caused by:
  process didn't exit successfully: `rustc --crate-name sin --edition=2021 examples/sin.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --diagnostic-width=196 --crate-type bin --emit=dep-info,link -C opt-level=3 -C lto=fat -C metadata=64de30f76d150efa -C extra-filename=-64de30f76d150efa --out-dir /data/vtjnash/rust-ml-autodiff-examples/target/release/examples -L dependency=/data/vtjnash/rust-ml-autodiff-examples/target/release/deps` (exit status: 1)
```