### PR TITLE
impl new modes for higher order ad

### DIFF
--- a/compiler/rustc_ast/src/expand/autodiff_attrs.rs
+++ b/compiler/rustc_ast/src/expand/autodiff_attrs.rs
@@ -11,6 +11,21 @@ pub enum DiffMode {
     Source,
     Forward,
     Reverse,
+    ForwardFirst,
+    ReverseFirst,
+}
+
+pub fn is_rev(mode: DiffMode) -> bool {
+    match mode {
+        DiffMode::Reverse | DiffMode::ReverseFirst => true,
+        _ => false,
+    }
+}
+pub fn is_fwd(mode: DiffMode) -> bool {
+    match mode {
+        DiffMode::Forward | DiffMode::ForwardFirst => true,
+        _ => false,
+    }
 }
 
 impl Display for DiffMode {
@@ -20,6 +35,8 @@ impl Display for DiffMode {
             DiffMode::Source => write!(f, "Source"),
             DiffMode::Forward => write!(f, "Forward"),
             DiffMode::Reverse => write!(f, "Reverse"),
+            DiffMode::ForwardFirst => write!(f, "ForwardFirst"),
+            DiffMode::ReverseFirst => write!(f, "ReverseFirst"),
         }
     }
 }
@@ -32,12 +49,12 @@ pub fn valid_ret_activity(mode: DiffMode, activity: DiffActivity) -> bool {
     match mode {
         DiffMode::Inactive => false,
         DiffMode::Source => false,
-        DiffMode::Forward => {
+        DiffMode::Forward | DiffMode::ForwardFirst => {
             activity == DiffActivity::Dual ||
                 activity == DiffActivity::DualOnly ||
                 activity == DiffActivity::Const
         }
-        DiffMode::Reverse => {
+        DiffMode::Reverse | DiffMode::ReverseFirst => {
             activity == DiffActivity::Const ||
                 activity == DiffActivity::Active ||
                 activity == DiffActivity::ActiveOnly
@@ -73,13 +90,13 @@ pub fn valid_input_activity(mode: DiffMode, activity: DiffActivity) -> bool {
         return match mode {
             DiffMode::Inactive => false,
             DiffMode::Source => false,
-            DiffMode::Forward => {
+            DiffMode::Forward | DiffMode::ForwardFirst => {
                 // These are the only valid cases
                 activity == DiffActivity::Dual ||
                     activity == DiffActivity::DualOnly ||
                     activity == DiffActivity::Const
             }
-            DiffMode::Reverse => {
+            DiffMode::Reverse | DiffMode::ReverseFirst => {
                 // These are the only valid cases
                 activity == DiffActivity::Active ||
                     activity == DiffActivity::ActiveOnly ||
@@ -137,6 +154,8 @@ impl FromStr for DiffMode {
             "Source" => Ok(DiffMode::Source),
             "Forward" => Ok(DiffMode::Forward),
             "Reverse" => Ok(DiffMode::Reverse),
+            "ForwardFirst" => Ok(DiffMode::ForwardFirst),
+            "ReverseFirst" => Ok(DiffMode::ReverseFirst),
             _ => Err(()),
         }
     }

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -879,8 +879,8 @@ pub(crate) unsafe fn enzyme_rust_forward_diff(
     let args_uncacheable = vec![0; input_tts.len()];
     assert!(args_uncacheable.len() == input_activity.len());
     let num_fnc_args = LLVMCountParams(fnc);
-    println!("num_fnc_args: {}", num_fnc_args);
-    println!("input_activity.len(): {}", input_activity.len());
+    trace!("num_fnc_args: {}", num_fnc_args);
+    trace!("input_activity.len(): {}", input_activity.len());
     assert!(num_fnc_args == input_activity.len() as u32);
 
     let kv_tmp = IntList { data: std::ptr::null_mut(), size: 0 };
@@ -893,6 +893,10 @@ pub(crate) unsafe fn enzyme_rust_forward_diff(
         KnownValues: known_values.as_mut_ptr(),
     };
 
+    trace!("ret_activity: {}", &ret_activity);
+    for i in &input_activity {
+        trace!("input_activity i: {}", &i);
+    }
     let res = EnzymeCreateForwardDiff(
         logic_ref, // Logic
         std::ptr::null(),
@@ -912,6 +916,7 @@ pub(crate) unsafe fn enzyme_rust_forward_diff(
         args_uncacheable.len(), // uncacheable arguments
         std::ptr::null_mut(),   // write augmented function to this
     );
+    dbg!(res);
     (res, vec![])
 }
 
@@ -971,10 +976,10 @@ pub(crate) unsafe fn enzyme_rust_reverse_diff(
         KnownValues: known_values.as_mut_ptr(),
     };
 
-    trace!("{}", &primary_ret);
-    trace!("{}", &ret_activity);
+    trace!("primary_ret: {}", &primary_ret);
+    trace!("ret_activity: {}", &ret_activity);
     for i in &input_activity {
-        trace!("{}", &i);
+        trace!("input_activity i: {}", &i);
     }
     let res = EnzymeCreatePrimalAndGradient(
         logic_ref, // Logic
@@ -998,6 +1003,7 @@ pub(crate) unsafe fn enzyme_rust_reverse_diff(
         std::ptr::null_mut(),   // write augmented function to this
         0,
     );
+    dbg!(res);
     (res, primal_sizes)
 }
 

--- a/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
+++ b/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
@@ -749,6 +749,8 @@ fn autodiff_attrs(tcx: TyCtxt<'_>, id: DefId) -> AutoDiffAttrs {
     let mode = match mode.as_str() {
         "Forward" => DiffMode::Forward,
         "Reverse" => DiffMode::Reverse,
+        "ForwardFirst" => DiffMode::ForwardFirst,
+        "ReverseFirst" => DiffMode::ReverseFirst,
         _ => {
             tcx.sess
                 .struct_span_err(attr.span, msg_mode)


### PR DESCRIPTION
Does currently not work, fails to diff the fwd function, the rev succeeds (forward-over-reverse example from julia docs).
Fails inside of Enzyme
```
    5 rustc: /h/344/drehwald/prog/rust/build/x86_64-unknown-linux-gnu/llvm/include/llvm/IR/Instructions.h:3144: llvm::Value* llvm::ReturnInst::getOperand(unsigned int) const: Assertion `i_nocapture < OperandTraits<ReturnInst>::operands(this) && "getOperand() out of range!"' failed.
```
Extra info during compiling the example:
`RUSTC_LOG=rustc_codegen_llvm::llvm=trace cargo +enzyme build `

Can you please look into it? I hope there is just some call setting wrong, but it would be nice if it would hit an enzyme assertion instead of an llvm one. Also, I here reuse the enzymelogicref, but the same issue happens if I don't.