### PR TITLE
chore: Use correct commit hash as github cache key if submodule is not checked out

### DIFF
--- a/.github/workflows/enzyme-ci.yml
+++ b/.github/workflows/enzyme-ci.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Checkout Rust source
         uses: actions/checkout@v4
         with:
+          submodules: true # check out all submodules so the cache can work correctly
           fetch-depth: 2
       - uses: dtolnay/rust-toolchain@nightly
       - name: Get LLVM commit hash

--- a/.github/workflows/enzyme-ci.yml
+++ b/.github/workflows/enzyme-ci.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
       - name: Get LLVM commit hash
         id: llvm-commit
-        run: echo "HEAD=$(git -C src/llvm-project rev-parse HEAD)" >> $GITHUB_OUTPUT
+        run: echo "HEAD=$(git rev-parse HEAD:src/llvm-project)" >> $GITHUB_OUTPUT
       - name: Cache LLVM
         id: cache-llvm
         uses: actions/cache@v4
@@ -37,7 +37,7 @@ jobs:
           key: ${{ matrix.os }}-llvm-${{ steps.llvm-commit.outputs.HEAD }}
       - name: Get Enzyme commit hash
         id: enzyme-commit
-        run: echo "HEAD=$(git -C src/tools/enzyme rev-parse HEAD)" >> $GITHUB_OUTPUT
+        run: echo "HEAD=$(git rev-parse HEAD:src/tools/enzyme)" >> $GITHUB_OUTPUT
       - name: Cache Enzyme
         id: cache-enzyme
         uses: actions/cache@v4


### PR DESCRIPTION
Previously, the CI workflow file used `git -C src/tools/enzyme` to try and execute a `rev-parse` inside the submodule. Unfortunately, this only works if that submodule is actually checked out and enzyme does not specify that. I am not quite sure where they are checked out *at all*, but clearly they are at some point.
The commit hash chosen for the key https://github.com/EnzymeAD/rust/issues/86#issuecomment-2028812352 here is neither the new nor the old enzyme commit, so this evidently didn't quite work out.

This PR changes the lookup to refer to the submodule instead, which should work regardless of its status on disk.