### PR TITLE
ci: update rustbook tests to use ENYZME_LOOSE_TYPES

### DIFF
--- a/.github/workflows/enzyme-ci.yml
+++ b/.github/workflows/enzyme-ci.yml
@@ -63,4 +63,4 @@ jobs:
         working-directory: rustbook
         run: |
           cargo +enzyme test
-          cargo +enzyme test -p samples-loose-types
+          ENZYME_LOOSE_TYPES=1 cargo +enzyme test -p samples-loose-types

--- a/.github/workflows/enzyme-ci.yml
+++ b/.github/workflows/enzyme-ci.yml
@@ -62,4 +62,5 @@ jobs:
       - name: test Enzyme/rustbook
         working-directory: rustbook
         run: |
-          cargo +enzyme test --workspace
+          cargo +enzyme test
+          cargo +enzyme test -p samples-loose-types


### PR DESCRIPTION
This depends on https://github.com/EnzymeAD/rustbook/pull/11