### PR TITLE
Adding Function Parameter + Return Attributes

### DIFF
--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -1,8 +1,7 @@
 #![allow(non_camel_case_types)]
 #![allow(non_upper_case_globals)]
 
-use crate::llvm::LLVMRustAddParamAttr;
-use crate::llvm::LLVMRustAddRetAttr;
+use crate::llvm::{LLVMRustAddParamAttr, LLVMRustAddRetAttr};
 
 use rustc_ast::expand::autodiff_attrs::DiffActivity;
 

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -1,6 +1,9 @@
 #![allow(non_camel_case_types)]
 #![allow(non_upper_case_globals)]
 
+use crate::llvm::LLVMRustAddParamAttr;
+use crate::llvm::LLVMRustAddRetAttr;
+
 use rustc_ast::expand::autodiff_attrs::DiffActivity;
 
 use super::debuginfo::{

--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -857,6 +857,21 @@ extern "C" void LLVMRustRemoveFncAttr(LLVMValueRef F,
   }
 }
 
+extern "C" void LLVMRustAddFncParamAttr(LLVMValueRef F, unsigned i,
+                                      LLVMAttributeRef RustAttr) {
+  if (auto *Fn = dyn_cast<Function>(unwrap<Value>(F))) {
+    Fn->addParamAttr(i, unwrap(RustAttr));
+  }
+}
+
+extern "C" void LLVMRustAddRetFncAttr(LLVMValueRef F,
+                                      LLVMRustAttribute RustAttr) {
+  // add return attribute
+  if (auto *Fn = dyn_cast<Function>(unwrap<Value>(F))) {
+    Fn->addRetAttr(fromRust(RustAttr));
+  }
+}
+
 extern "C" LLVMMetadataRef LLVMRustDIGetInstMetadata(LLVMValueRef x) {
   if (auto *I = dyn_cast<Instruction>(unwrap<Value>(x))) {
     // auto *MD = I->getMetadata(LLVMContext::MD_dbg);
@@ -880,10 +895,6 @@ extern "C" void LLVMRustAddParamAttr(LLVMValueRef call, unsigned i,
   if (auto *CI = dyn_cast<CallInst>(unwrap<Value>(call))) {
     CI->addParamAttr(i, unwrap(RustAttr));
   }
-}
-
-extern "C" void LLVMRustAddRetAttr() {
-  // add return attribute
 }
 
 extern "C" void LLVMRustDISetInstMetadata(LLVMValueRef Inst,

--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -882,6 +882,10 @@ extern "C" void LLVMRustAddParamAttr(LLVMValueRef call, unsigned i,
   }
 }
 
+extern "C" void LLVMRustAddRetAttr() {
+  // add return attribute
+}
+
 extern "C" void LLVMRustDISetInstMetadata(LLVMValueRef Inst,
                                           LLVMMetadataRef Desc) {
   if (auto *I = dyn_cast<Instruction>(unwrap<Value>(Inst))) {


### PR DESCRIPTION
Adding the functions `LLVMRustAddFncParamAttr` and `LLVMRustAddRetFncAttr` to RustWrapper.cpp.

This will be used so that later we can link type trees to specific parameters/return value for Enzyme.