### PR TITLE
Adding Function Parameter + Return Attributes

### DIFF
--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -3,6 +3,8 @@
 
 use rustc_ast::expand::autodiff_attrs::DiffActivity;
 
+use crate::llvm::{LLVMRustAddFncParamAttr, LLVMRustAddRetAttr};
+
 use super::debuginfo::{
     DIArray, DIBasicType, DIBuilder, DICompositeType, DIDerivedType, DIDescriptor, DIEnumerator,
     DIFile, DIFlags, DIGlobalVariableExpression, DILexicalBlock, DILocation, DINameSpace,
@@ -1022,6 +1024,13 @@ extern "C" {
     // EraseFromParent doesn't exist :(
     //pub fn LLVMEraseFromParent(BB: &BasicBlock) -> &Value;
     // Enzyme
+    pub fn LLVMRustAddFncParamAttr<'a>(
+        Instr: &'a Value,
+        index: c_uint,
+        Attr: &'a Attribute
+    );
+
+    pub fn LLVMRustAddRetAttr(V: &Value, attr: AttributeKind);
     pub fn LLVMRustRemoveFncAttr(V: &Value, attr: AttributeKind);
     pub fn LLVMRustHasDbgMetadata(I: &Value) -> bool;
     pub fn LLVMRustHasMetadata(I: &Value, KindID: c_uint) -> bool;

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -3,8 +3,6 @@
 
 use rustc_ast::expand::autodiff_attrs::DiffActivity;
 
-use crate::llvm::{LLVMRustAddFncParamAttr, LLVMRustAddRetAttr};
-
 use super::debuginfo::{
     DIArray, DIBasicType, DIBuilder, DICompositeType, DIDerivedType, DIDescriptor, DIEnumerator,
     DIFile, DIFlags, DIGlobalVariableExpression, DILexicalBlock, DILocation, DINameSpace,

--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -857,6 +857,20 @@ extern "C" void LLVMRustRemoveFncAttr(LLVMValueRef F,
   }
 }
 
+extern "C" void LLVMRustAddFncParamAttr(LLVMValueRef F, unsigned i,
+                                      LLVMAttributeRef RustAttr) {
+  if (auto *Fn = dyn_cast<Function>(unwrap<Value>(F))) {
+    Fn->addParamAttr(i, unwrap(RustAttr));
+  }
+}
+
+extern "C" void LLVMRustAddRetFncAttr(LLVMValueRef F,
+                                      LLVMRustAttribute RustAttr) {
+  if (auto *Fn = dyn_cast<Function>(unwrap<Value>(F))) {
+    Fn->addRetAttr(fromRust(RustAttr));
+  }
+}
+
 extern "C" LLVMMetadataRef LLVMRustDIGetInstMetadata(LLVMValueRef x) {
   if (auto *I = dyn_cast<Instruction>(unwrap<Value>(x))) {
     // auto *MD = I->getMetadata(LLVMContext::MD_dbg);


### PR DESCRIPTION
Adding the functions `LLVMRustAddFncParamAttr` and `LLVMRustAddRetFncAttr` to RustWrapper.cpp.

This will be used so that later we can link type trees to specific parameters/return value for Enzyme.

For the c->rust wrapper, do I add an implementation for the `LLVMRustAddFncParamAttr`, `LLVMRustAddRetAttr` functions?

Also do I need lines 6-7?