### PR TITLE
ci: add RUSTFLAGS='-Z unstable-options' for check-cfg

### DIFF
--- a/.github/workflows/enzyme-ci.yml
+++ b/.github/workflows/enzyme-ci.yml
@@ -86,5 +86,5 @@ jobs:
       - name: test Enzyme/rustbook
         working-directory: rustbook
         run: |
-          cargo +enzyme test
-          ENZYME_LOOSE_TYPES=1 cargo +enzyme test -p samples-loose-types
+          RUSTFLAGS='-Z unstable-options' cargo +enzyme test
+          ENZYME_LOOSE_TYPES=1 RUSTFLAGS='-Z unstable-options' cargo +enzyme test -p samples-loose-types


### PR DESCRIPTION
Otherwise we get errors:
```
error: the `-Z unstable-options` flag must also be passed to enable the flag `check-cfg`
```
I think this can be dropped after EnzymeAD/rust is rebased on recent upstream, where this feature has been stabilized.