### PR TITLE
Fix `README.md` typo for running `x.py`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Please configure this fork using the following command:
 
 Afterwards you can build rustc using:
 ```
-x.py build --stage 1 library
+./x.py build --stage 1 library
 ```
 
 Afterwards rustc toolchain link will allow you to use it through cargo:


### PR DESCRIPTION
This PR fixes a typo in the part of the README describing how to run the `x.py` script.